### PR TITLE
Added API methods for POST/PATCH/PUT/DELETE, implemented term deletion.

### DIFF
--- a/mocks/terms.ts
+++ b/mocks/terms.ts
@@ -1,0 +1,14 @@
+export default [
+  {
+    _id: '13',
+    value: 'First Term',
+  },
+  {
+    _id: '37',
+    value: 'Second Term',
+  },
+  {
+    _id: '42',
+    value: 'Third Term',
+  },
+];

--- a/src/Jank/TermManagement/Term.tsx
+++ b/src/Jank/TermManagement/Term.tsx
@@ -1,15 +1,31 @@
-import React from 'react';
-import { DeleteButton, TermText } from './ui';
+import React, { useCallback } from 'react';
+
+import useErrorHandler from '../../hooks/useErrorHandler';
+import { remove } from '../../services/api.service';
+import { Action } from './types';
+import { DeleteButton, TermText, ErrorText } from './ui';
+import { deleteTerm } from './actions';
 
 type TermProps = {
-  value: string
+  id: string,
+  value: string,
+  dispatch: (action: Action) => void
 }
 
-const Term = ({ value } : TermProps) => (
-  <li>
-    <TermText>{value}</TermText>
-    <DeleteButton type="button">X</DeleteButton>
-  </li>
-);
+const Term = ({ id, value, dispatch }: TermProps) => {
+  const callback = useCallback(async () => {
+    await remove(`/jank/terms/${id}`);
+    dispatch(deleteTerm(id));
+  }, [dispatch, id]);
+  const [error, onClick] = useErrorHandler(callback);
+
+  return (
+    <li>
+      <TermText>{value}</TermText>
+      <DeleteButton onClick={onClick} type="button">X</DeleteButton>
+      {error && <ErrorText>Begriff konnte nicht gelöscht werden.</ErrorText>}
+    </li>
+  );
+};
 
 export default Term;

--- a/src/Jank/TermManagement/TermList.tsx
+++ b/src/Jank/TermManagement/TermList.tsx
@@ -1,18 +1,29 @@
-import React from 'react';
-import Term from './Term';
-import useApi from '../../hooks/useApi';
-import { AddButton, AddLabel, TermInput } from './ui';
+import React, { useEffect, useReducer } from 'react';
 
-type Terms = {
-  _id: string,
-  value: string
-}
+import useApi from '../../hooks/useApi';
+import reducer from './reducer';
+import TermItem from './Term';
+import { Term } from './types';
+import {
+  AddButton,
+  AddLabel,
+  ErrorText,
+  TermInput,
+} from './ui';
+import { setTerms } from './actions';
 
 const TermList = () => {
-  const [error, terms] = useApi<Terms[]>('/jank/terms');
+  const [error, apiTerms] = useApi<Term[]>('/jank/terms');
+  const [terms, dispatch] = useReducer(reducer, []);
+
+  useEffect(() => {
+    if (apiTerms !== null) {
+      dispatch(setTerms(apiTerms));
+    }
+  }, [apiTerms]);
 
   if (error) {
-    return <span>Begriffe konnten leider nicht geladen werden</span>;
+    return <ErrorText>Begriffe konnten leider nicht geladen werden</ErrorText>;
   }
   return (
     <>
@@ -26,7 +37,7 @@ const TermList = () => {
       </form>
       <ul>
         {terms && terms.map(({ _id, value }) => (
-          <Term key={_id} value={value} />
+          <TermItem key={_id} id={_id} value={value} dispatch={dispatch} />
         ))}
       </ul>
     </>

--- a/src/Jank/TermManagement/__tests__/actions.test.ts
+++ b/src/Jank/TermManagement/__tests__/actions.test.ts
@@ -1,0 +1,39 @@
+import { setTerms, addTerm, deleteTerm } from '../actions';
+import { ActionType } from '../types';
+import terms from '../../../../mocks/terms';
+
+describe('term actions', () => {
+  describe('setTerms', () => {
+    it('has type `Set`', () => {
+      expect(setTerms(terms)).toHaveProperty('type', ActionType.Set);
+    });
+
+    it('has provided terms as its payload', () => {
+      expect(setTerms(terms)).toHaveProperty('payload', terms);
+    });
+  });
+
+  describe('addTerm', () => {
+    const [term] = terms;
+
+    it('has type `Add`', () => {
+      expect(addTerm(term)).toHaveProperty('type', ActionType.Add);
+    });
+
+    it('has provided term as its payload', () => {
+      expect(addTerm(term)).toHaveProperty('payload', term);
+    });
+  });
+
+  describe('deleteTerm', () => {
+    const { _id: id } = terms[0];
+
+    it('has type `Delete`', () => {
+      expect(deleteTerm(id)).toHaveProperty('type', ActionType.Delete);
+    });
+
+    it('has provided ID as its payload', () => {
+      expect(deleteTerm(id)).toHaveProperty('payload', id);
+    });
+  });
+});

--- a/src/Jank/TermManagement/__tests__/reducer.test.ts
+++ b/src/Jank/TermManagement/__tests__/reducer.test.ts
@@ -1,0 +1,86 @@
+import { setTerms, addTerm, deleteTerm } from '../actions';
+import reducer from '../reducer';
+import { Action } from '../types';
+import terms from '../../../../mocks/terms';
+
+describe('term reducer', () => {
+  describe('`setTerms`', () => {
+    it('sets the terms for an empty state', () => {
+      expect(reducer([], setTerms(terms))).toStrictEqual(terms);
+    });
+
+    it('replaces existing terms', () => {
+      const existingTerms = [{
+        _id: '5',
+        value: 'Exists',
+      }, {
+        _id: '25',
+        value: 'Also exists',
+      }];
+      expect(reducer(existingTerms, setTerms(terms))).toStrictEqual(terms);
+    });
+  });
+
+  describe('`addTerm`', () => {
+    const [term] = terms;
+    it('adds a term to an empty state', () => {
+      expect(reducer([], addTerm(term))).toStrictEqual([term]);
+    });
+
+    it('adds a term to a list of existing terms', () => {
+      const existingTerms = [{
+        _id: '5',
+        value: 'Exists',
+      }, {
+        _id: '25',
+        value: 'Also exists',
+      }];
+      const state = reducer(existingTerms, addTerm(term));
+
+      expect(state).toContain(term);
+      expect(state).toStrictEqual(expect.arrayContaining(existingTerms));
+    });
+  });
+
+  describe('`deleteTerm`', () => {
+    it('does nothing to an empty state', () => {
+      expect(reducer([], deleteTerm('anything'))).toStrictEqual([]);
+    });
+
+    it('deletes a term from a list of existing terms', () => {
+      const [firstTerm, secondTerm, thirdTerm] = terms;
+      const { _id: id } = secondTerm;
+      const state = reducer(terms, deleteTerm(id));
+
+      expect(state).toContain(firstTerm);
+      expect(state).not.toContain(secondTerm);
+      expect(state).toContain(thirdTerm);
+    });
+
+    it('deletes nothing if term does not exist in list of existing terms', () => {
+      const existingTerms = [{
+        _id: '5',
+        value: 'Exists',
+      }, {
+        _id: '25',
+        value: 'Also exists',
+      }];
+      expect(reducer(existingTerms, deleteTerm('42'))).toStrictEqual(existingTerms);
+    });
+  });
+
+  describe('unknown action', () => {
+    const action = {
+      type: 'unknown',
+      payload: 'unknown',
+    } as unknown as Action;
+
+    it('returns empty state if state is empty', () => {
+      expect(reducer([], action)).toStrictEqual([]);
+    });
+
+    it('returns existing terms if state contains terms', () => {
+      expect(reducer(terms, action)).toStrictEqual(terms);
+    });
+  });
+});

--- a/src/Jank/TermManagement/actions.ts
+++ b/src/Jank/TermManagement/actions.ts
@@ -1,0 +1,35 @@
+import { Term, ActionType } from './types';
+
+/**
+ * Creates and returns an action to set the list of available terms.
+ *
+ * @param terms the terms to set
+ * @returns the action that can be dispatched to set terms
+ */
+export const setTerms = (terms: Term[]) => ({
+  type: ActionType.Set,
+  payload: terms,
+});
+
+/**
+ * Creates and returns an action to add a term.
+ *
+ * @param term the term to add
+ * @returns the action that can be dispatched to add a term
+ */
+export const addTerm = (term: Term) => ({
+  type: ActionType.Add,
+  payload: term,
+});
+
+
+/**
+ * Creates and returns an action to delete a term.
+ *
+ * @param id the ID of the term to delete
+ * @returns the action that can be dispatched to delete a term
+ */
+export const deleteTerm = (id: string) => ({
+  type: ActionType.Delete,
+  payload: id,
+});

--- a/src/Jank/TermManagement/reducer.ts
+++ b/src/Jank/TermManagement/reducer.ts
@@ -1,0 +1,23 @@
+import { Term, Action, ActionType } from './types';
+
+/**
+ * State reducer for terms, handling an action that was dispatched.
+ *
+ * @param state the current state, containing the list of terms
+ * @param action the dispatched action to handle
+ * @returns the new state after the dispatched action was handled
+ */
+const reducer = (state: Term[], action: Action) => {
+  switch (action.type) {
+    case ActionType.Set:
+      return action.payload as Term[];
+    case ActionType.Add:
+      return [...state, action.payload as Term];
+    case ActionType.Delete:
+      return state.filter(({ _id }) => _id !== action.payload);
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/Jank/TermManagement/types.ts
+++ b/src/Jank/TermManagement/types.ts
@@ -1,0 +1,15 @@
+export enum ActionType {
+  Set,
+  Add,
+  Delete,
+}
+
+export interface Term {
+  _id: string,
+  value: string,
+}
+
+export interface Action {
+  type: ActionType,
+  payload: Term[] | Term | string,
+}

--- a/src/Jank/TermManagement/ui.tsx
+++ b/src/Jank/TermManagement/ui.tsx
@@ -19,6 +19,11 @@ export const AddButton = styled(Button)`
   font-size: ${fontSize}px;
 `;
 
+export const ErrorText = styled.span`
+  color: red;
+  font-weight: bold;
+`;
+
 export const TermText = styled.span`
   margin-top: 10px;
   font-size: ${fontSize}px;

--- a/src/hooks/__tests__/useErrorHandler.test.ts
+++ b/src/hooks/__tests__/useErrorHandler.test.ts
@@ -1,0 +1,38 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import useErrorHandler from '../useErrorHandler';
+
+describe('useErrorHandler', () => {
+  it('returns no error when initialized', () => {
+    const { result } = renderHook(() => useErrorHandler(async () => { }));
+    const [error] = result.current;
+
+    expect(error).toBeNull();
+  });
+
+  it('returns an executable handler', () => {
+    const callback = jest.fn();
+    const { result } = renderHook(() => useErrorHandler(callback));
+    const handler = result.current[1];
+
+    act(() => {
+      handler();
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an error if handler failes', async () => {
+    const expectedError = new Error('Expected error');
+    const callback = jest.fn().mockRejectedValueOnce(expectedError);
+    const { result } = renderHook(() => useErrorHandler(callback));
+    const handler = result.current[1];
+
+    await act(async () => {
+      handler();
+    });
+
+    const [error] = result.current;
+    expect(error).toBe(expectedError);
+  });
+});

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 
-const BASE_URL = '/api';
+import { get } from '../services/api.service';
+import useErrorHandler from './useErrorHandler';
 
 /**
  * Fetches resources from an API endpoint and returns them.
@@ -11,28 +12,15 @@ const BASE_URL = '/api';
  */
 const useApi = <T>(path: string): [Error | null, T | null] => {
   const [result, setResult] = useState<T | null>(null);
-  const [error, setError] = useState<Error | null>(null);
+  const callback = useCallback(async () => {
+    setResult(null);
+    setResult(await get(path));
+  }, [path]);
+  const [error, handler] = useErrorHandler(callback);
 
   useEffect(() => {
-    const sendRequest = async () => {
-      setResult(null);
-      setError(null);
-
-      try {
-        const response = await fetch(`${BASE_URL}${path}`);
-
-        if (!response.ok) {
-          throw new Error(`Request to ${path} failed: ${response.statusText}`);
-        }
-
-        setResult(await response.json());
-      } catch (e) {
-        setError(e);
-      }
-    };
-
-    sendRequest();
-  }, [path]);
+    handler();
+  }, [handler]);
 
   return [error, result];
 };

--- a/src/hooks/useErrorHandler.ts
+++ b/src/hooks/useErrorHandler.ts
@@ -1,0 +1,24 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Executes a callback in an error handler, providing any error as a state variable
+ *
+ * @param callback the callback to use the error handler for
+ * @returns the error, if any, along with the error handler wrapping the callback
+ */
+const useErrorHandler = (callback: () => Promise<void>): [Error | null, () => Promise<void>] => {
+  const [error, setError] = useState<Error | null>(null);
+  const handler = useCallback(async () => {
+    setError(null);
+
+    try {
+      await callback();
+    } catch (e) {
+      setError(e);
+    }
+  }, [callback]);
+
+  return [error, handler];
+};
+
+export default useErrorHandler;

--- a/src/services/__tests__/api.service.test.ts
+++ b/src/services/__tests__/api.service.test.ts
@@ -1,0 +1,85 @@
+import {
+  get,
+  post,
+  patch,
+  put,
+  remove,
+} from '../api.service';
+
+describe('methods without data', () => {
+  describe.each([get, remove])('%p', (method) => {
+    it('returns response JSON if request succeeds', async () => {
+      const expectedResult = { test: 42 };
+      const response = new Response(JSON.stringify(expectedResult));
+      jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
+      const result = await method('/foo/success');
+      expect(result).toStrictEqual(expectedResult);
+    });
+
+    it('returns no response if request succeeds but response is empty', async () => {
+      const response = new Response('', { status: 204 });
+      jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
+      const result = await method('/foo/success');
+      expect(result).toBeNull();
+    });
+
+    it('returns an error if response contains error', async () => {
+      const response = new Response('Expected error response', {
+        status: 400,
+        statusText: 'Bad Request',
+      });
+      jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
+      await expect(method('/foo/errorResponse'))
+        .rejects.toThrow('Request to /foo/errorResponse failed: Bad Request');
+    });
+
+    it('returns an error if request fails', async () => {
+      const error = new Error('Expected error');
+      jest.spyOn(window, 'fetch').mockRejectedValue(error);
+
+      await expect(method('/foo/errorResponse')).rejects.toThrow(error);
+    });
+  });
+});
+
+describe('methods with data', () => {
+  describe.each([post, patch, put])('%p with data', (method) => {
+    it('returns response JSON if request succeeds', async () => {
+      const expectedResult = { id: 13 };
+      const response = new Response(JSON.stringify(expectedResult));
+      jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
+      const result = await method('/foo/success', { test: 37 });
+      expect(result).toStrictEqual(expectedResult);
+    });
+
+    it('returns no response if request succeeds but response is empty', async () => {
+      const response = new Response('', { status: 204 });
+      jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
+      const result = await method('/foo/success', { test: 37 });
+      expect(result).toBeNull();
+    });
+
+    it('returns an error if response contains error', async () => {
+      const response = new Response('Expected error response', {
+        status: 400,
+        statusText: 'Bad Request',
+      });
+      jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
+      await expect(method('/foo/errorResponse', { test: 37 }))
+        .rejects.toThrow('Request to /foo/errorResponse failed: Bad Request');
+    });
+
+    it('returns an error if request fails', async () => {
+      const error = new Error('Expected error');
+      jest.spyOn(window, 'fetch').mockRejectedValue(error);
+
+      await expect(method('/foo/errorResponse', { test: 37 })).rejects.toThrow(error);
+    });
+  });
+});

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -1,0 +1,80 @@
+/**
+ * The base URL to prepend to all request URLs.
+ */
+const BASE_URL = '/api';
+
+/**
+ * Sends a request using the provided options, and returns the response, if any.
+ *
+ * @param method the HTTP method to use for sending the request
+ * @param path the path to the API endpoint to send the request to
+ * @param init the init options to pass to `fetch()`
+ * @returns a promise for the response, containing the parsed JSON, if available
+ */
+const request = async (method: string, path: string, init?: RequestInit) => {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method,
+    ...init,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request to ${path} failed: ${response.statusText}`);
+  }
+
+  return response.status === 204 ? null : response.json();
+};
+
+/**
+ * Sends a request with a JSON body using the provided options.
+ *
+ * @param method the HTTP method to use for sending the request
+ * @param path the path to the API endpoint to send the request to
+ * @param data the data to send as JSON in the request body
+ * @returns a promise for the response, containing the parsed JSON, if available
+ */
+const requestWithData = (method: string, path: string, data: object) => request(method, path, {
+  headers: {
+    'Content-Type': 'application/json',
+    body: JSON.stringify(data),
+  },
+});
+
+/**
+ * Sends a GET request to the specified path to retrieve resources.
+ *
+ * @param path the path to get resources from
+ * @return the parsed response body
+ */
+export const get = (path: string) => request('GET', path);
+
+/**
+ * Sends a POST request to the specified path to create a resource.
+ *
+ * @param path the path to POST a resource to
+ * @param data the data to send in the request body
+ * @return the parsed response body, if available
+ */
+export const post = (path: string, data: object) => requestWithData('POST', path, data);
+
+/**
+ * Sends a PATCH request to the specified path to update a resource.
+ *
+ * @param path the path to PATCH a resource at
+ * @param data the data to send in the request body
+ */
+export const patch = (path: string, data: object) => requestWithData('PATCH', path, data);
+
+/**
+ * Sends a PUT request to the specified path to create or update a resource.
+ *
+ * @param path the path to PUT the resource to
+ * @param data the data to send in the request body
+ */
+export const put = (path: string, data: object) => requestWithData('PUT', path, data);
+
+/**
+ * Sends a DELETE request to the specified path to remove a resource.
+ *
+ * @param path the path to the resource to DELETE
+ */
+export const remove = (path: string) => request('DELETE', path);

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -5,4 +5,5 @@
 import '@testing-library/jest-dom/extend-expect';
 
 jest.spyOn(window, 'fetch').mockImplementation(
-  () => Promise.reject(new Error('Fetch was called without being mocked')));
+  () => Promise.reject(new Error('Fetch was called without being mocked')),
+);


### PR DESCRIPTION
This PR provides access to endpoints that require POST/PATCH/PUT/DELETE via helper functions and hooks for error handling. In addition, the deletion for terms was implemented as an example, using a reducer and action dispatchers.

The reducer is implemented using built-in React hooks - this is a common pattern for state handling, maybe it makes sense to set up a short session for this so I can explain what is going on. Unless you already know about reducers and action dispatchers. In general it's not that complicated, but wrapping one's hand around it might be a bit confusing at first glance.